### PR TITLE
Move the language server out of the vscode plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # Unreleased
 
+* We're standardizing on the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol) so that we can support a larger number of editors with less code that is specific to Polymer and our editor service. Open protocols FTW!
+  * Our old homegrown protocol, used by the atom and sublime text plugins is deprecated. We'll be updating those plugins to use the LSP in upcoming releases. ETA end of November 2016.
+
 * Greatly improve contextual autocompletion. The context determiner now understands comments, inline script and style elements, and template contents. We also now correctly handle a vast number of edge cases. [commit](https://github.com/Polymer/polymer-analyzer/commit/3ff3196d6f1b6a0ab8598a8f4aeeaa5328fa755b). [pull request](https://github.com/Polymer/polymer-analyzer/pull/348)
 
 * Prototyped initially with [vscode](https://github.com/Polymer/vscode-plugin), followed by [atom](https://github.com/Polymer/atom-plugin) and then [https://github.com/Polymer/polymer-sublime-plugin](sublime).

--- a/LICENSE
+++ b/LICENSE
@@ -3,3 +3,23 @@ This code may only be used under the BSD style license found at http://polymer.g
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+
+
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,25 +14,8 @@ These editor plugins use the editor service:
 
 The Editor Service exposes the power of [the analyzer](https://github.com/Polymer/polymer-analyzer) as a standalone service for text editor integration.
 
-It is intended to run out-of-process of the text editor and communicate over a JSON protocol. For editors like atom and vscode we provide a nodejs library, `remote-editor-service.js` that handles spawning and communicating with this process. For other editors we provide a nodejs binary `polymer-editor-server` that communicates over stdin and stdout.
-
-### Demo
-
-`polymer-editor-server` speaks newline-separated JSON objects over stdin and stdout.
-
-    $ node lib/polymer-editor-server.js # or just:  polymer-editor-server
-
-```json
-    {"id": 0, "value": {"kind": "init", "basedir": "lib/test/static"}}
-
-    {"id":0,"value":{"kind":"resolution"}}
-
-    {"id": 1, "value": {"kind": "getWarningsFor", "localPath": "malformed.html"}}
-
-    {"id":1,"value":{"kind":"resolution","resolution":[{"message":"Unexpected token <","severity":0,"code":"parse-error","sourceRange":{"file":"malformed.html","start":{"line":266,"column":0},"end":{"line":266,"column":0}}}]}}
-```
-
 ### Protocol
 
-See `src/editor-service/remote-editor-protocol.ts` for documentation on the protocol.
+The `polymer-language-service` command speaks the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol) over stdin and stdout.
 
+`polymer-editor-server` and its nonstandard protocol are deprecated, and we'll be migrating the atom and sublime text plugins over to use the `polymer-language-service` soon. The differences are fairly minor and migration should be done by the end of November 2016.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/split": "^0.3.28",
     "polymer-analyzer": "=2.0.0-alpha.16",
     "split": "^1.0.0",
-    "typescript": "^2.0.3"
+    "typescript": "^2.0.3",
+    "vscode-languageserver": "^3.0.0-alpha.1"
   }
 }

--- a/src/polymer-language-server.ts
+++ b/src/polymer-language-server.ts
@@ -1,0 +1,269 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright multiple authors.
+ * See ../LICENSE for license information.
+ ------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Implements the [language server protocol][1] v2.0 for Web Components and
+ * Polymer.
+ *
+ * Communicates over stdin/stdout.
+ *
+ * [1]: https://github.com/Microsoft/language-server-protocol
+ */
+
+import * as path from 'path';
+
+import {CompletionList, Location, Range, createConnection, IConnection, TextDocuments, TextDocument, Diagnostic, DiagnosticSeverity, InitializeResult, TextDocumentPositionParams, CompletionItem, CompletionItemKind, Position as LSPosition} from 'vscode-languageserver';
+import {FSUrlLoader} from 'polymer-analyzer/lib/url-loader/fs-url-loader';
+import {PackageUrlResolver} from 'polymer-analyzer/lib/url-loader/package-url-resolver';
+import {Severity, WarningCarryingException} from 'polymer-analyzer/lib/warning/warning';
+
+import {LocalEditorService} from 'polymer-analyzer/lib/editor-service/local-editor-service';
+import {EditorService, SourcePosition, TypeaheadCompletion} from 'polymer-analyzer/lib/editor-service/editor-service';
+
+import {SourceRange} from 'polymer-analyzer/lib/model/model';
+
+interface SettingsWrapper {
+  polymerVscodePlugin: Settings;
+}
+
+// The settings defined in the client's package.json file.
+interface Settings {}
+
+// Create a connection for the server. Communicate using stdio.
+let connection: IConnection = createConnection(process.stdin, process.stdout);
+
+// The settings have changed. Is sent on server activation as well.
+connection.onDidChangeConfiguration((change) => {
+  let settings = <SettingsWrapper>change.settings;
+  // TODO(rictic): use settings for real
+  settings.polymerVscodePlugin;
+});
+
+let editorService: EditorService|null = null;
+
+// Create a simple text document manager. The text document manager
+// supports full document sync only
+// TODO(rictic): for speed, sync diffs instead.
+let documents: TextDocuments = new TextDocuments();
+
+// Make the text document manager listen on the connection
+// for open, change and close text document events
+documents.listen(connection);
+
+// After the server has started the client sends an initilize request. The
+// server receives in the passed params the rootPath of the workspace plus the
+// client capabilites.
+let workspaceRoot: string;
+connection.onInitialize((params): InitializeResult => {
+  workspaceRoot = params.rootPath;
+  editorService = new LocalEditorService({
+    urlLoader: new FSUrlLoader(workspaceRoot),
+    urlResolver: new PackageUrlResolver()
+  });
+  documents.all().forEach(d => scanDocument(d));
+  return <InitializeResult>{
+    capabilities: {
+      // Tell the client that the server works in FULL text document sync mode
+      textDocumentSync: documents.syncKind,
+      // Tell the client that the server support code complete
+      completionProvider: {resolveProvider: false},
+      hoverProvider: true,
+      definitionProvider: true,
+    }
+  };
+});
+
+// The content of a text document has changed. This event is emitted
+// when the text document is first opened or when its content has changed.
+documents.onDidChangeContent((change) => {
+  scanDocument(change.document, connection);
+});
+
+
+connection.onHover(async(textPosition) => {
+  return handleErrors(getDocsForHover(textPosition));
+});
+
+async function getDocsForHover(textPosition: TextDocumentPositionParams) {
+  const localPath = getWorkspacePathToFile(textPosition.textDocument);
+  if (localPath && editorService) {
+    const documentation = await editorService.getDocumentationAtPosition(
+        localPath, convertPosition(textPosition.position));
+    if (documentation) {
+      return {contents: documentation};
+    }
+  }
+}
+
+connection.onDefinition(async(textPosition) => {
+  return handleErrors(getDefinition(textPosition));
+});
+
+async function getDefinition(textPosition: TextDocumentPositionParams) {
+  const localPath = getWorkspacePathToFile(textPosition.textDocument);
+  if (localPath && editorService) {
+    const location = await editorService.getDefinitionForFeatureAtPosition(
+        localPath, convertPosition(textPosition.position));
+    if (location && location.file) {
+      let definition: Location = {
+        uri: getUriForLocalPath(location.file),
+        range: convertRange(location)
+      };
+      return definition;
+    }
+  }
+}
+
+// This handler provides the initial list of the completion items.
+connection.onCompletion(async(textPosition) => {
+  return handleErrors(autoComplete(textPosition));
+});
+
+async function autoComplete(textPosition: TextDocumentPositionParams):
+    Promise<CompletionList|undefined> {
+  const localPath = getWorkspacePathToFile(textPosition.textDocument);
+  if (!localPath || !editorService) {
+    return;
+  }
+  const completions: (TypeaheadCompletion|undefined) =
+      await editorService.getTypeaheadCompletionsAtPosition(
+          localPath, convertPosition(textPosition.position));
+  if (!completions) {
+    return;
+  }
+  if (completions.kind === 'element-tags') {
+    return {
+      isIncomplete: false,
+      items: completions.elements.map(c => {
+        return <CompletionItem>{
+          label: `<${c.tagname}>`,
+          kind: CompletionItemKind.Class,
+          documentation: c.description,
+          insertText: c.expandTo
+        };
+      }),
+    };
+  } else if (completions.kind === 'attributes') {
+    return {
+      isIncomplete: false,
+      items: completions.attributes.map(a => {
+        const item: CompletionItem = {
+          label: a.name,
+          kind: CompletionItemKind.Field,
+          documentation: a.description,
+          sortText: a.sortKey
+        };
+        if (a.type) {
+          item.detail = `{${a.type}}`;
+        }
+        if (a.inheritedFrom) {
+          if (item.detail) {
+            item.detail = `${item.detail} ⊃ ${a.inheritedFrom}`;
+          } else {
+            item.detail = `⊃ ${a.inheritedFrom}`;
+          }
+        }
+        return item;
+      }),
+    };
+  }
+}
+
+function getWorkspacePathToFile(doc: {uri: string}): string|undefined {
+  // We only support file urls. Extract everything after file:///
+  // Note the third slash. We pull that out too. See the absolute path
+  // generation code below.
+  const match = doc.uri.match(/^file:\/\/\/?(.*)/);
+  if (!match || !match[1] || !workspaceRoot) {
+    return undefined;
+  }
+  // Decode the URI encoding. TODO: something something unicode?
+  const decodedPath = decodeURIComponent(match[1]);
+  // We've stripped off the leading `/`, which on unix means that we have a
+  // relative-looking path, but on Windows we still have an absolute path that
+  // starts with e.g. `C:\`. We can normalize these two by forcing both into
+  // an absolute path, like so:
+  const absolutePath = path.resolve('/', decodedPath);
+  // But what the editor service really wants is a path relative to the
+  // workspace root. So do that.
+  return path.relative(workspaceRoot, absolutePath);
+}
+
+function getUriForLocalPath(localPath: string): string {
+  return `file://${workspaceRoot}/${localPath}`;
+}
+
+function convertPosition(position: LSPosition): SourcePosition {
+  return {line: position.line, column: position.character};
+}
+
+function convertRange(range: SourceRange): Range {
+  return {
+    start: {line: range.start.line, character: range.start.column},
+    end: {line: range.end.line, character: range.end.column}
+  };
+}
+
+function convertSeverity(severity: Severity): DiagnosticSeverity {
+  switch (severity) {
+    case Severity.ERROR:
+      return DiagnosticSeverity.Error;
+    case Severity.WARNING:
+      return DiagnosticSeverity.Warning;
+    case Severity.INFO:
+      return DiagnosticSeverity.Information;
+    default:
+      throw new Error(
+          `This should never happen. Got a severity of ${severity}`);
+  }
+}
+
+function scanDocument(document: TextDocument, connection?: IConnection) {
+  return handleErrors(_scanDocument(document, connection));
+}
+
+async function _scanDocument(document: TextDocument, connection?: IConnection) {
+  if (editorService) {
+    const localPath = getWorkspacePathToFile(document);
+    if (!localPath) {
+      return;
+    }
+    editorService.fileChanged(localPath, document.getText());
+
+    if (connection) {
+      const diagnostics: Diagnostic[] = [];
+      const warnings = await editorService.getWarningsForFile(localPath);
+      for (const warning of warnings) {
+        diagnostics.push({
+          code: warning.code,
+          message: warning.message,
+          range: convertRange(warning.sourceRange),
+          source: 'polymer-ide',
+          severity: convertSeverity(warning.severity),
+        });
+      }
+      connection.sendDiagnostics({diagnostics, uri: document.uri});
+    }
+  }
+}
+
+async function handleErrors<Result>(promise: Promise<Result>):
+    Promise<Result|undefined> {
+  try {
+    return await promise;
+  } catch (err) {
+    // Ignore WarningCarryingExceptions, they're expected, and made visible
+    //   to the user in a useful way. All other exceptions should be logged
+    //   if possible.
+    if (connection && !(err instanceof WarningCarryingException)) {
+      connection.console.error(err.stack || err.message || err);
+    }
+    return undefined;
+  }
+}
+
+// Listen on the connection
+connection.listen();


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->
- [x] CHANGELOG.md has been updated

Moved from https://github.com/polymer/vscode-plugin

Once this is released we'll migrate the other plugins to use this rather than our home-grown protocol, and deprecate then remove the editor server.
