### PR TITLE
[Parked] Update for analyzer 3.0's switch to babel.

### DIFF
--- a/src/test/editor-service_test.ts
+++ b/src/test/editor-service_test.ts
@@ -634,7 +634,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
       assert.containSubset(
           warnings, <Warning[]>[{
             code: 'could-not-load',
-            message: 'Unable to load import: Unexpected token ,',
+            message: 'Unable to load import: Unexpected token (18:8)',
             severity: Severity.ERROR,
             sourceRange: {
               file: 'editor-service/index.html',
@@ -664,7 +664,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           warnings, <Warning[]>[{
             code: 'parse-error',
             severity: Severity.ERROR,
-            message: 'Unexpected token var',
+            message: 'Unexpected token (1:4)',
             sourceRange: {file: 'editor-service/index.html'}
           }]);
       const underliner =
@@ -691,7 +691,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           await editorService.getWarningsForFile('js-parse-error.js');
       deepEqual(JSON.parse(JSON.stringify(warnings)), [{
                   code: 'parse-error',
-                  message: 'Unexpected token ,',
+                  message: 'Unexpected token (18:8)',
                   severity: Severity.ERROR,
                   sourceRange: {
                     file: 'js-parse-error.js',


### PR DESCRIPTION
 - [x] CHANGELOG.md not updated, this is internal to the editor service
 - [ ] https://github.com/Polymer/polymer-analyzer/pull/749 must be released

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-editor-service/73)
<!-- Reviewable:end -->
